### PR TITLE
Add Java support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -68,6 +68,10 @@ The source code is available on GitHub [here](https://github.com/maptz/Maptz.VSC
 
 ## Release Notes
 
+### Version 1.0.5
+
+- Added support for `Java`.
+
 ### Version 1.0.4
 
 - Fixed issue that command didn't show up in the command palette. [Issue #17](https://github.com/maptz/maptz.vscode.extensions.customfolding/issues/17)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "regionfolder",
-    "version": "0.0.8",
+    "version": "1.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "regionfolder",
     "displayName": "#region folding for VS Code",
     "description": "Provides folding for text wrapped with #region comments in VS Code.",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "homepage": "https://raw.githubusercontent.com/maptz/Maptz.VSCode.Extensions.customfolding/master/ReadMe.md",
     "repository": "https://github.com/maptz/Maptz.VSCode.Extensions.customfolding",
     "publisher": "maptz",
@@ -48,7 +48,7 @@
             }
         },
         "configurationDefaults": {
-            
+
         }
     },
     "scripts": {

--- a/src/IConfiguration.ts
+++ b/src/IConfiguration.ts
@@ -70,6 +70,12 @@ export let DefaultConfiguration :IConfiguration = {
     foldStart: "/* #region  [NAME] */",
     foldStartRegex: "^[\\s]*/\\*[\\s]*#region[\\s]*(.*)[\\s]*\\*/[\\s]*$"
   },
+  "[java]": {
+    foldEnd: "/* #endregion */",
+    foldEndRegex: "/\\*[\\s]*#endregion",
+    foldStart: "/* #region [NAME] */",
+    foldStartRegex: "^[\\s]*/\\*[\\s]*#region[\\s]*(.*)[\\s]*\\*/[\\s]*$"
+  },
   "[json]": {
     foldEnd: "/* #endregion */",
     foldEndRegex: "/\\*[\\s]*#endregion",


### PR DESCRIPTION
Enabled support for `Java`, bumped version number to 1.0.5.

Would be great if you could merge this, region support has been sorely lacking from Java editors (at least afaik).