### PR TITLE
fix example for custom language

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -34,13 +34,13 @@ To provide a custom folding for your language create a settings in your vscode s
 
     "maptz.regionfolder": {
         "[ahk]": {                                      //Language selector
-            foldEnd: "; #endregion",                    //Text inserted at the end of the fold
-            foldEndRegex: ";[\\s]*#endregion",          //Regex used to find fold end text.
-            foldStart: "; #region [NAME]",              //Text inserted at the start of the fold.
+            "foldEnd": "; #endregion",                    //Text inserted at the end of the fold
+            "foldEndRegex": ";[\\s]*#endregion",          //Regex used to find fold end text.
+            "foldStart": "; #region [NAME]",              //Text inserted at the start of the fold.
                                                         //Use the `[NAME]` placeholder to indicate
                                                         //where the cursor should be placed after
                                                         //insertion
-            foldStartRegex: ";[\\s]*#region[\\s]*(.*)"  ////Regex used to find fold start text.
+            "foldStartRegex": ";[\\s]*#region[\\s]*(.*)"  ////Regex used to find fold start text.
       }
     }
 


### PR DESCRIPTION
Property keys must be double quoted in json. 
Thank you for your extension, very usefull.