### PR TITLE
Add Oracle PLSQL Setting

### DIFF
--- a/src/config/DefaultConfiguration.ts
+++ b/src/config/DefaultConfiguration.ts
@@ -105,6 +105,12 @@ export let DefaultConfiguration: IConfig.IConfiguration = {
     defaultFoldStartRegex: "\\<!--[\\s]*#region\\(collapsed\\)[\\s]*(.*)",
     foldStartRegex: "\\<!--[\\s]*#region[\\s]*(.*)"
   },
+  "[oraclesql]": {                                          
+    foldEnd: "/* #endregion */",                         
+    foldEndRegex: "/* [\\s]*#endregion [\\s]*(.*)*/",    
+    foldStart: "/* #region [NAME] */",                   
+    foldStartRegex: "/* [\\s]*#region[\\s]*(.*)*/",      
+  },
   "[php]": {
     foldEnd: "/* #endregion */",
     foldEndRegex: "/\\*[\\s]*#endregion",


### PR DESCRIPTION
Hello, I use your extension since Oracle's extension https://www.oracle.com/database/technologies/appdev/dotnet/odtvscodequickstart.html has some quirk's/bugs with folding. This is the settings I have in my user file. I've added them to your defaults. Let me know if there's anything else I should be doing but this looked to be it. 