### PR TITLE
Add json with comments (jsonc).

### DIFF
--- a/src/config/DefaultConfiguration.ts
+++ b/src/config/DefaultConfiguration.ts
@@ -98,6 +98,12 @@ export let DefaultConfiguration: IConfig.IConfiguration = {
     foldStart: "/* #region  [NAME] */",
     foldStartRegex: "^[\\s]*/\\*[\\s]*#region[\\s]*(.*)[\\s]*\\*/[\\s]*$"
   },
+  "[jsonc]": {
+    foldEnd: "/* #endregion */",
+    foldEndRegex: "/\\*[\\s]*#endregion",
+    foldStart: "/* #region  [NAME] */",
+    foldStartRegex: "^[\\s]*/\\*[\\s]*#region[\\s]*(.*)[\\s]*\\*/[\\s]*$"
+  },
   "[lua]": {
     foldEnd: "--#endregion",
     foldEndRegex: "--[\\s]*#endregion",


### PR DESCRIPTION
VSCode reads its settings.json file as JSON with comments if you use any comments in it. I would like to be able to use this plugin with it without having to switch the language to JSON each time.