### PR TITLE
Added a prefix to the title of each command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,35 +21,35 @@
         "commands": [
             {
                 "command": "regionfolder.collapseAllRegions",
-                "title": "Collapse all #regions."
+                "title": "Region folding: Collapse all #regions."
             },
             {
                 "command": "regionfolder.collapseDefault",
-                "title": "Collapse default #regions."
+                "title": "Region folding: Collapse default #regions."
             },
             {
                 "command": "regionfolder.deleteRegion",
-                "title": "Delete current #region tags and contents"
+                "title": "Region folding: Delete current #region tags and contents"
             },
             {
                 "command": "regionfolder.removeCurrentRegionTags",
-                "title": "Delete current #region tags"
+                "title": "Region folding: Delete current #region tags"
             },
             {
                 "command": "regionfolder.wrapWithRegion",
-                "title": "Wrap selection with #region tag."
+                "title": "Region folding: Wrap selection with #region tag."
             },
             {
                 "command": "regionfolder.wrapWithRegionAndComment",
-                "title": "Wrap with #region tag and comment."
+                "title": "Region folding: Wrap with #region tag and comment."
             },
             {
                 "command": "regionfolder.selectCurrentRegion",
-                "title": "Select current #region."
+                "title": "Region folding: Select current #region."
             },
             {
                 "command": "regionfolder.selectCurrentRegionContents",
-                "title": "Select current #region contents."
+                "title": "Region folding: Select current #region contents."
             }
         ],
         "keybindings": [
@@ -65,7 +65,7 @@
             }
         ],
         "configuration": {
-            "title": "Maptz region folding configuration",
+            "title": "Region folding: Maptz region folding configuration",
             "type": "object",
             "properties": {
                 "maptz.regionfolder": {


### PR DESCRIPTION
## Problem

The current title of region folding commands doesn't have prefixes, which breaks the consistency of executing commands from the command palette.

<img width="641" alt="image" src="https://user-images.githubusercontent.com/41246463/183346888-3925512e-39a2-4035-879b-e588769a5ce6.png">

## Solution

This PR resolves the problem above by adding the prefix "Region folding: "to the title of each command.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/41246463/183349045-cea81e5f-26d6-4dd8-818d-15a4e9414eff.png">

