### PR TITLE
Added support for RestructuredText

### DIFF
--- a/src/config/DefaultConfiguration.ts
+++ b/src/config/DefaultConfiguration.ts
@@ -164,6 +164,12 @@ export let defaultConfiguration: IConfig.IConfiguration = {
     foldStart: "#region [NAME]",
     foldStartRegex: "[\\s]*#region[\\s]*(.*)"
   },
+  "[restructuredtext]": {                       //Language selector
+    foldEnd: ".. #endregion",
+    foldEndRegex: "^[\\s]*\\.\\.[\\s]*#endregion[\\s]*$",
+    foldStart: ".. #region [NAME]",
+    foldStartRegex: "^[\\s]*\\.\\.[\\s]*#region[\\s]*.*[\\s]*$",
+  },
   "[ruby]": {                                      //Language selector
     foldEnd: "#endregion",
     foldEndRegex: "[\\s]*#endregion",


### PR DESCRIPTION
I personally installed this extension to work with RestructuredText files (.rst files, an alternative to markdown), as mine get huge, and there is zero folding by default in VScode for these files. I got it to work in my own VScode settings.json, and added that working version using this PR.
I don't know the ins and outs of programming my own VScode extensions (I just know about installing from the built-in marketplace), so have not tried installing/compiling this edited version. I hope it is still useful!